### PR TITLE
fix: 刷新课程类别选项框

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -183,12 +183,11 @@ function customStaticUI(catsList) {
         // $('#btn_sortSetting').css('display', 'none');
     }
 
-    // 如果没有添加课程选项框
-    if ($('input[name="x-selbox"]').length === 0) {
-        addCourseSelectBox(catsList);
-    } else {
-        $('input[name="x-selbox"]').prop('checked', true);
-    }
+    // 刷新课程选项框
+    // 按照原来的逻辑，请求过来的课程类别可能会在选择学年、学期后刷新，但课程选项框不会一起刷新
+    // 这里直接刷新课程选项框
+    document.querySelector('.x-controls-container')?.remove();
+    addCourseSelectBox(catsList);
 }
 
 /**

--- a/js/script.js
+++ b/js/script.js
@@ -255,11 +255,12 @@ function customStaticUI(catsList) {
         // $('#btn_sortSetting').css('display', 'none');
     }
 
-    // 刷新课程选项框
-    // 按照原来的逻辑，请求过来的课程类别可能会在选择学年、学期后刷新，但课程选项框不会一起刷新
-    // 这里直接刷新课程选项框
-    document.querySelector('.x-controls-container')?.remove();
-    addCourseSelectBox(catsList);
+    // 如果没有添加课程选项框
+    if ($('input[name="x-selbox"]').length === 0) {
+        addCourseSelectBox(catsList);
+    } else {
+        $('input[name="x-selbox"]').prop('checked', true);
+    }
 }
 
 /**

--- a/js/script.js
+++ b/js/script.js
@@ -9,7 +9,11 @@ let _config = {
         1: true, // 学年
         2: true, // 学期
         5: false, // 课程性质
-    }
+    },
+    headerSorts: {}, // 表头排序模式
+    multiSort: false, // 是否支持多键排序
+    lastClickedHeader: undefined, // 最后被点击的表头
+    keyOrders: [1, 2, 5], // KEY排序顺序(目前要求键的优先性：学年>学期>课程性质>自定义的一列)
 };
 
 /***** 图表相关的全局变量 *****/
@@ -54,12 +58,64 @@ $(window).unload(function () {
     localStorage.setItem(KEY_CONFIG, JSON.stringify(_config));
 });
 
+/**
+ * 合并配置
+ * @param {*} default_ 默认配置
+ * @param {*} new_ 新配置
+ * @returns 合并后的配置
+ */
+function mergeConfig(default_, new_) {
+    if (new_ === null || new_ === undefined) return default_;
+    if (typeof default_ !== typeof new_) {
+        return new_;
+    }
+    if (typeof default_ === 'object') {
+        if (Array.isArray(default_)) {
+            return Array.isArray(new_) ? new_ : default_;
+        }
+
+        const newObj = {};
+        for (key in default_) {
+            newObj[key] = mergeConfig(default_[key], new_[key]);
+        }
+        return newObj;
+    }
+
+    return new_;
+}
+
+/**
+ * 加载配置
+ */
 function loadConfig() {
     const json = localStorage.getItem(KEY_CONFIG);
     const maybe = JSON.parse(json);
-    if (maybe && maybe['sorts']) {  // 务必进行校验和对配置进行迁移
-        _config = maybe;
+    _config = mergeConfig(_config, maybe);
+
+    if (_config.multiSort) {
+        // TODO 实现自定义多键排序（点击表头多键排序需要解决考虑键的优先性）
+        console.warn("暂不支持自定义多键排序");
+        _config.multiSort = false;
     }
+    _config.lastClickedHeader = undefined;
+}
+
+/**
+ * 获取排序设置
+ * @returns {[ {[key in number]: boolean}, number[] ]} 返回一个包含排序模式的对象以及键优先序列的数组。
+ */
+function getSortsMode() {
+    const keyOrders =
+        (
+            _config.multiSort
+                ? [..._config.keyOrders, ...Object.keys(_config.headerSorts)]
+                : [..._config.keyOrders, _config.lastClickedHeader]
+        )
+            .filter((_, x) => x !== undefined);
+    const sortsMode = _config.multiSort
+        ? { ..._config.sorts, ..._config.headerSorts, }
+        : { ..._config.sorts, [_config.lastClickedHeader]: _config.headerSorts[_config.lastClickedHeader] };
+    return [sortsMode, keyOrders];
 }
 
 /**
@@ -67,9 +123,11 @@ function loadConfig() {
  */
 $(window).on('load', function () {
     loadConfig();
+    bindAllHeaderClickEvent();
 
     fetchScores();
 
+    // TODO 使用 hook 替换
     const originalDialog = $.dialog;
     $.dialog = function (options) {
         const hookedForSort = options && options['modalName'] === 'sortModal';
@@ -88,10 +146,23 @@ $(window).on('load', function () {
                 : options
         );
         if (hookedForSort) bindAllSortsModeEvent();
-        
+
         return result;
     }
 });
+
+/**
+ * HOOK
+ * @param {object} object 被拦截对象
+ * @param {string} functionKey 函数KEY
+ * @param {(original: Function, ...args: any[]) => object} handler 处理函数
+ */
+function hook(object, functionKey, handler) {
+    const original = object[functionKey];
+    object[functionKey] = function () {
+        return handler(original, ...arguments);
+    }
+}
 
 function fetchScores() {
     $('#searchForm .chosen-select').first().val('');
@@ -197,7 +268,7 @@ function sortScores() {
     let rows = $('table:eq(1)')
         .find('tr:gt(0)')
         .toArray()
-        .sort(comparator(_config.sorts));
+        .sort(comparator(getSortsMode()));
     rows.splice(0, 0, $('table:eq(1)').find('tr:eq(0)'));
     $('table:eq(1)').children('tbody').empty().html(rows);
 
@@ -370,6 +441,48 @@ function bindAllSortsModeEvent() {
     bindSortModeEvent(_config.sorts, 5, 2);
 
     $('#sort_table_body tr:eq(2) td:eq(1)').first().text('课程性质');
+}
+
+/**
+ * 绑定表头单击事件（以便自定义表头排序）
+ */
+function bindAllHeaderClickEvent() {
+    function selectMode(span, asc) {
+        if (asc === undefined) {
+            span.css('display', 'none');
+            return;
+        }
+        span.css('display', 'inline');
+        span.find(`span[sort=${asc ? 'asc' : 'desc'}]`).removeClass('ui-state-disabled');
+        span.find(`span[sort=${!asc ? 'asc' : 'desc'}]`).addClass('ui-state-disabled');
+    }
+
+    $('.ui-jqgrid-htable tr th')
+        .each(function (index, th) {
+            if (index === 0) return;
+
+            th = $(th);
+            const div = th.find('div');
+            const span = div.find('span.s-ico');
+
+            if (_config.headerSorts[index] !== undefined) {
+                selectMode(span, _config.headerSorts[index]);
+            }
+
+            if (_config.multiSort) th.unbind('click');
+            div.on('click', function () {
+                _config.lastClickedHeader = index;
+
+                // 升序 -> 降序 -> 不排序
+                if (_config.headerSorts[index] === false) {
+                    _config.headerSorts[index] = undefined;
+                    _config.lastClickedHeader = undefined;
+                }
+                else
+                    _config.headerSorts[index] = !_config.headerSorts[index];
+                selectMode(span, _config.headerSorts[index]);
+            });
+        });
 }
 
 /**
@@ -556,10 +669,10 @@ function getCellValue(row, index) {
 
 /**
  * 根据传入的列索引数组，返回一个依次比较各列的比较器函数
- * @param {Array} indexes 包含需要作为排序标准的列索引值，0-based, 顺序很重要
+ * @param {[ {[key in number]: boolean}, number[] ]} 一个包含排序模式的对象以及键优先序列的数组。
  * @returns 返回一个comparator function
  */
-function comparator(indexes) {
+function comparator([indexes, keys]) {
 
     const compare = (valA, valB) => {
         if ($.isNumeric(valA) && $.isNumeric(valB)) {
@@ -571,7 +684,7 @@ function comparator(indexes) {
     return function (a, b) {
         let ans = 0;
 
-        for (const i in indexes) {
+        for (const i of keys) {
             let valA = getCellValue(a, i),
                 valB = getCellValue(b, i);
 

--- a/js/script.js
+++ b/js/script.js
@@ -166,6 +166,7 @@ function hook(object, functionKey, handler) {
 
 function fetchScores() {
     $('#searchForm .chosen-select').first().val('');
+    $('#searchForm .chosen-select').eq(1).val('');
     $('#searchForm .chosen-select').last().val('');
     $('.chosen-single span').text('全部');
 

--- a/js/script.js
+++ b/js/script.js
@@ -132,7 +132,7 @@ function customDynamicUI() {
 
     const catsList = []; // 获取课程类别的数组，未去重
     $('table:eq(1) tr:gt(0)').each(function () {
-        const score = parseFloat($(this).find('td:eq(7)').text());
+        const score = parseFloat($(this).find('td:eq(22)').text());
         if (score >= 60.0) {
             $(this)
                 .find('td:eq(3)')
@@ -635,7 +635,7 @@ function calcSemGPA(year, sem) {
             let row = [];
             if ($(this).find('input[name="x-course-select"]').is(':checked')) {
                 $(this)
-                    .find('td:eq(6), td:eq(7), td:eq(9)')
+                    .find('td:eq(6), td:eq(22), td:eq(8)')
                     .each(function () {
                         row.push($.trim($(this).text()));
                     });
@@ -656,7 +656,7 @@ function updateHeaderScores() {
         let row = [];
         if ($(this).find('input[name="x-course-select"]').is(':checked')) {
             $(this)
-                .find('td:eq(6), td:eq(7), td:eq(9)')
+                .find('td:eq(6), td:eq(22), td:eq(8)')
                 .each(function () {
                     row.push($.trim($(this).text()));
                 });
@@ -685,7 +685,7 @@ function updateSemScores() {
                 let row = [];
                 if ($(this).find('input[name="x-course-select"]').is(':checked')) {
                     $(this)
-                        .find('td:eq(6), td:eq(7), td:eq(9)')
+                        .find('td:eq(6), td:eq(22), td:eq(8)')
                         .each(function () {
                             row.push($.trim($(this).text()));
                         });

--- a/js/script.js
+++ b/js/script.js
@@ -9,11 +9,7 @@ let _config = {
         1: true, // 学年
         2: true, // 学期
         5: false, // 课程性质
-    },
-    headerSorts: {}, // 表头排序模式
-    multiSort: false, // 是否支持多键排序
-    lastClickedHeader: undefined, // 最后被点击的表头
-    keyOrders: [1, 2, 5], // KEY排序顺序(目前要求键的优先性：学年>学期>课程性质>自定义的一列)
+    }
 };
 
 /***** 图表相关的全局变量 *****/
@@ -58,64 +54,12 @@ $(window).unload(function () {
     localStorage.setItem(KEY_CONFIG, JSON.stringify(_config));
 });
 
-/**
- * 合并配置
- * @param {*} default_ 默认配置
- * @param {*} new_ 新配置
- * @returns 合并后的配置
- */
-function mergeConfig(default_, new_) {
-    if (new_ === null || new_ === undefined) return default_;
-    if (typeof default_ !== typeof new_) {
-        return new_;
-    }
-    if (typeof default_ === 'object') {
-        if (Array.isArray(default_)) {
-            return Array.isArray(new_) ? new_ : default_;
-        }
-
-        const newObj = {};
-        for (key in default_) {
-            newObj[key] = mergeConfig(default_[key], new_[key]);
-        }
-        return newObj;
-    }
-
-    return new_;
-}
-
-/**
- * 加载配置
- */
 function loadConfig() {
     const json = localStorage.getItem(KEY_CONFIG);
     const maybe = JSON.parse(json);
-    _config = mergeConfig(_config, maybe);
-
-    if (_config.multiSort) {
-        // TODO 实现自定义多键排序（点击表头多键排序需要解决考虑键的优先性）
-        console.warn("暂不支持自定义多键排序");
-        _config.multiSort = false;
+    if (maybe && maybe['sorts']) {  // 务必进行校验和对配置进行迁移
+        _config = maybe;
     }
-    _config.lastClickedHeader = undefined;
-}
-
-/**
- * 获取排序设置
- * @returns {[ {[key in number]: boolean}, number[] ]} 返回一个包含排序模式的对象以及键优先序列的数组。
- */
-function getSortsMode() {
-    const keyOrders =
-        (
-            _config.multiSort
-                ? [..._config.keyOrders, ...Object.keys(_config.headerSorts)]
-                : [..._config.keyOrders, _config.lastClickedHeader]
-        )
-            .filter((_, x) => x !== undefined);
-    const sortsMode = _config.multiSort
-        ? { ..._config.sorts, ..._config.headerSorts, }
-        : { ..._config.sorts, [_config.lastClickedHeader]: _config.headerSorts[_config.lastClickedHeader] };
-    return [sortsMode, keyOrders];
 }
 
 /**
@@ -123,11 +67,9 @@ function getSortsMode() {
  */
 $(window).on('load', function () {
     loadConfig();
-    bindAllHeaderClickEvent();
 
     fetchScores();
 
-    // TODO 使用 hook 替换
     const originalDialog = $.dialog;
     $.dialog = function (options) {
         const hookedForSort = options && options['modalName'] === 'sortModal';
@@ -146,23 +88,10 @@ $(window).on('load', function () {
                 : options
         );
         if (hookedForSort) bindAllSortsModeEvent();
-
+        
         return result;
     }
 });
-
-/**
- * HOOK
- * @param {object} object 被拦截对象
- * @param {string} functionKey 函数KEY
- * @param {(original: Function, ...args: any[]) => object} handler 处理函数
- */
-function hook(object, functionKey, handler) {
-    const original = object[functionKey];
-    object[functionKey] = function () {
-        return handler(original, ...arguments);
-    }
-}
 
 function fetchScores() {
     $('#searchForm .chosen-select').first().val('');
@@ -270,7 +199,7 @@ function sortScores() {
     let rows = $('table:eq(1)')
         .find('tr:gt(0)')
         .toArray()
-        .sort(comparator(getSortsMode()));
+        .sort(comparator(_config.sorts));
     rows.splice(0, 0, $('table:eq(1)').find('tr:eq(0)'));
     $('table:eq(1)').children('tbody').empty().html(rows);
 
@@ -443,48 +372,6 @@ function bindAllSortsModeEvent() {
     bindSortModeEvent(_config.sorts, 5, 2);
 
     $('#sort_table_body tr:eq(2) td:eq(1)').first().text('课程性质');
-}
-
-/**
- * 绑定表头单击事件（以便自定义表头排序）
- */
-function bindAllHeaderClickEvent() {
-    function selectMode(span, asc) {
-        if (asc === undefined) {
-            span.css('display', 'none');
-            return;
-        }
-        span.css('display', 'inline');
-        span.find(`span[sort=${asc ? 'asc' : 'desc'}]`).removeClass('ui-state-disabled');
-        span.find(`span[sort=${!asc ? 'asc' : 'desc'}]`).addClass('ui-state-disabled');
-    }
-
-    $('.ui-jqgrid-htable tr th')
-        .each(function (index, th) {
-            if (index === 0) return;
-
-            th = $(th);
-            const div = th.find('div');
-            const span = div.find('span.s-ico');
-
-            if (_config.headerSorts[index] !== undefined) {
-                selectMode(span, _config.headerSorts[index]);
-            }
-
-            if (_config.multiSort) th.unbind('click');
-            div.on('click', function () {
-                _config.lastClickedHeader = index;
-
-                // 升序 -> 降序 -> 不排序
-                if (_config.headerSorts[index] === false) {
-                    _config.headerSorts[index] = undefined;
-                    _config.lastClickedHeader = undefined;
-                }
-                else
-                    _config.headerSorts[index] = !_config.headerSorts[index];
-                selectMode(span, _config.headerSorts[index]);
-            });
-        });
 }
 
 /**
@@ -671,10 +558,10 @@ function getCellValue(row, index) {
 
 /**
  * 根据传入的列索引数组，返回一个依次比较各列的比较器函数
- * @param {[ {[key in number]: boolean}, number[] ]} 一个包含排序模式的对象以及键优先序列的数组。
+ * @param {Array} indexes 包含需要作为排序标准的列索引值，0-based, 顺序很重要
  * @returns 返回一个comparator function
  */
-function comparator([indexes, keys]) {
+function comparator(indexes) {
 
     const compare = (valA, valB) => {
         if ($.isNumeric(valA) && $.isNumeric(valB)) {
@@ -686,7 +573,7 @@ function comparator([indexes, keys]) {
     return function (a, b) {
         let ans = 0;
 
-        for (const i of keys) {
+        for (const i in indexes) {
             let valA = getCellValue(a, i),
                 valB = getCellValue(b, i);
 


### PR DESCRIPTION
请求过来的课程类别可能会在选择学年、学期后刷新，但按照原来的逻辑，插件渲染的课程选项框不会一起刷新。
这里每次都会刷新课程选项框。