### PR TITLE
Refactor: 计算部分统一传参为 [学分，GPA，成绩] 模式; Fix: 成绩表格列移动带来的兼容性问题

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -44,29 +44,28 @@ $.ajaxSetup({
                 fromUpdateGrades = true;
             }
         } catch (error) {
-            // console.log(error);
         }
         return data;
     }
 });
 
-$(window).unload(function () {
-    localStorage.setItem(KEY_CONFIG, JSON.stringify(_config));
-});
+// $(window).unload(function () {
+//     localStorage.setItem(KEY_CONFIG, JSON.stringify(_config));
+// });
 
-function loadConfig() {
-    const json = localStorage.getItem(KEY_CONFIG);
-    const maybe = JSON.parse(json);
-    if (maybe && maybe['sorts']) {  // 务必进行校验和对配置进行迁移
-        _config = maybe;
-    }
-}
+// function loadConfig() {
+//     const json = localStorage.getItem(KEY_CONFIG);
+//     const maybe = JSON.parse(json);
+//     if (maybe && maybe['sorts']) {  // 务必进行校验和对配置进行迁移
+//         _config = maybe;
+//     }
+// }
 
 /**
  * 文档加载完成后，触发查询按钮click事件，获取全部成绩
  */
 $(window).on('load', function () {
-    loadConfig();
+    // loadConfig();
 
     fetchScores();
 
@@ -88,7 +87,7 @@ $(window).on('load', function () {
                 : options
         );
         if (hookedForSort) bindAllSortsModeEvent();
-        
+
         return result;
     }
 });

--- a/js/script.js
+++ b/js/script.js
@@ -20,7 +20,7 @@ let plots = null; // 全局变量，画图的echartsInstance实例，方便关�
 let creditsDataset = [];
 
 // 每学期的成绩记录数组
-// Array of Array[semester, credits count, average GPa, cumu GPA, average score, cumu score]
+// Array of Array[semester, credits count, average GPA, cumu GPA, average score, cumu score]
 let recordDataset = [];
 
 /***** end of 图表相关的全局变量 *****/

--- a/js/script.js
+++ b/js/script.js
@@ -380,16 +380,27 @@ function bindAllSortsModeEvent() {
 function bindEvents() {
     // 响应表格中的复选框
     $('input[name="x-course-select"]').change(() => {
-        // 根据表格中选择的课程类别更新对应课程类别复选框的状态
-        // 如果存在对应课程被选中，则课程类别复选框为勾选状态；否则取消勾选
-        $('input[name="x-selbox"]').each(function() {
-            const category = $(this).val();
-            const hasCheckedCourse = $('table:eq(1) tr:gt(0)').filter(function() {
-                return $(this).find('td:eq(5)').text() === category &&
-                       $(this).find('input[name="x-course-select"]').is(':checked');
-            }).length > 0;
-            $(this).prop('checked', hasCheckedCourse);
-        });
+        /**
+         * The course category checkboxes are for conveniently including or excluding an entire category of courses from GPA calculation.
+         * The individual course checkboxes are for fine-grained GPA calculation control.
+         * These two features have different design intents. A better approach would be to provide UX hints to clarify their distinction.
+
+         * There's a clear bug in the current synchronization logic:
+         * If there are two or more "Cross-School Major Required" courses, and one of them is unchecked (excluded) via its course checkbox,
+         * the parent "Cross-School Major Required" category checkbox becomes checked. This contradicts the design intent of the category checkbox.
+         * 
+         * Decision: Commented out for now. Keep it simple.
+         */
+        // // 根据表格中选择的课程类别更新对应课程类别复选框的状态
+        // // 如果存在对应课程被选中，则课程类别复选框为勾选状态；否则取消勾选
+        // $('input[name="x-selbox"]').each(function () {
+        //     const category = $(this).val();
+        //     const hasCheckedCourse = $('table:eq(1) tr:gt(0)').filter(function () {
+        //         return $(this).find('td:eq(4)').text() === category &&
+        //             $(this).find('input[name="x-course-select"]').is(':checked');
+        //     }).length > 0;
+        //     $(this).prop('checked', hasCheckedCourse);
+        // });
         updateAllScores();
     });
 
@@ -433,6 +444,15 @@ function bindEvents() {
             }).length > 0;
             $(this).prop('checked', hasCheckedCourse);
         });
+        // See line 394-404 for the reason why this is commented out.
+        // $('input[name="x-selbox"]').each(function () {
+        //     const category = $(this).val();
+        //     const hasCheckedCourse = $('table:eq(1) tr:gt(0)').filter(function () {
+        //         return $(this).find('td:eq(4)').text() === category &&
+        //             $(this).find('input[name="x-course-select"]').is(':checked');
+        //     }).length > 0;
+        //     $(this).prop('checked', hasCheckedCourse);
+        // });
         updateAllScores();
     });
 

--- a/js/script.js
+++ b/js/script.js
@@ -632,8 +632,8 @@ function comparator(indexes) {
  */
 function calcGPA(scores) {
     let totalCredits = 0,
-        totalGPA = 0;
-        totalScore = 0,
+        totalGPA = 0,
+        totalScore = 0;
     $(scores).each(function () {
         let credit = parseFloat($(this)[0]);
         let GPA = parseFloat($(this)[1]);


### PR DESCRIPTION
- Refactor: 计算部分统一传参为 `[学分，GPA，成绩]` 模式；
- Fix: 复选框事件绑定部分，增强了课程类别复选框、表格复选框和按钮之间的联动性。即：
- - 对于全选/全不选按钮，仅当没有勾选状态时显示”全选“；
- - 对于课程类别复选框，仅当该类别没有处于勾选状态的课程时不被勾选。
